### PR TITLE
Improve social metadata, baseurl safety, and font fallbacks

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,4 +9,4 @@ permalink: /404.html
 
 <p>There's nothing here.</p>
 
-<p><a href="/">Home page?</a></p>
+<p><a href="{{ '/' | relative_url }}">Home page?</a></p>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,9 +15,9 @@
     <!-- Open Graph -->
     <meta property="og:title" content="{% if page.title == 'Home' %}{{ site.SEOtitle }}{% else %}{{ page.title }} · {{ site.title }}{% endif %}">
     <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | truncate: 110 }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
-    <meta property="og:image" content="{{ site.url }}{{ site.logo }}">
-    <meta property="og:image:alt" content="{{ site.title }} logo">
-    <meta property="og:url" content="{{ site.url }}{{ page.url }}">
+    <meta property="og:image" content="{{ page.image | default: site.logo | absolute_url }}">
+    <meta property="og:image:alt" content="{{ page.image_alt | default: site.title }}">
+    <meta property="og:url" content="{{ page.url | absolute_url }}">
     <meta property="og:type" content="{% if page.layout == 'post' %}article{% else %}website{% endif %}">
     <meta property="og:site_name" content="{{ site.title }}">
     
@@ -25,8 +25,8 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="{% if page.title == 'Home' %}{{ site.SEOtitle }}{% else %}{{ page.title }} · {{ site.title }}{% endif %}">
     <meta name="twitter:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | truncate: 110 }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
-    <meta name="twitter:image" content="{{ site.url }}{{ site.logo }}">
-    <meta name="twitter:image:alt" content="{{ site.title }} logo">
+    <meta name="twitter:image" content="{{ page.image | default: site.logo | absolute_url }}">
+    <meta name="twitter:image:alt" content="{{ page.image_alt | default: site.title }}">
 
     <!-- Feeds -->
     <link rel="alternate" title="{{ site.title }} (ATOM feed)" type="application/atom+xml" href="{{ "/feed.xml" | absolute_url }}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <header class="top-bar">
-    <a href="/" aria-label="Home - {{ site.title }}">{{ site.topbar }}</a>
+    <a href="{{ '/' | relative_url }}" aria-label="Home - {{ site.title }}">{{ site.topbar }}</a>
 </header>

--- a/_sass/_blog-index.scss
+++ b/_sass/_blog-index.scss
@@ -82,6 +82,6 @@
   border-bottom: 1px solid var(--color-primary-light);
   padding: 4px;
   color: var(--color-primary);
-  font-family: moniker;
+  font-family: var(--font-sans);
   font-weight: 700;
 }

--- a/_sass/_common.scss
+++ b/_sass/_common.scss
@@ -25,12 +25,15 @@
     --color-background-light: #f9f9f9;
     --color-background-hover: #fdf6f4;
     --color-border: #eee;
+    --font-sans: "Moniker", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    --font-display: "Bryant", "Moniker", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    --font-mono: "Iosevka Term", "Fira Code", Consolas, "Liberation Mono", monospace;
 }
 
 .blog-date {
     margin-left: 2px;
     text-transform: uppercase;
-    font-family: bryant;
+    font-family: var(--font-display);
     font-size: 0.833rem;
     color: var(--color-primary-light);
     font-weight: 700
@@ -256,7 +259,7 @@ textarea {
 
 html {
     color: #333;
-    font-family: moniker
+    font-family: var(--font-sans)
 }
 
 h3 {
@@ -266,7 +269,7 @@ h3 {
 }
 
 code,pre,tt {
-    font-family: iosevka term
+    font-family: var(--font-mono)
 }
 
 .highlight>pre {
@@ -529,7 +532,7 @@ code,pre,tt {
 
 .blog-tags .tags-list small {
     text-transform: uppercase;
-    font-family: bryant;
+    font-family: var(--font-display);
     margin: 0.5em;
     color: var(--color-primary-light);
 }
@@ -583,7 +586,7 @@ code,pre,tt {
     margin-top: 2rem;
     margin-bottom: 0;
     text-transform: uppercase;
-    font-family: bryant;
+    font-family: var(--font-display);
     font-size: 1.333rem
 }
 
@@ -591,7 +594,7 @@ code,pre,tt {
     margin-top: 2rem;
     margin-bottom: 0;
     text-transform: uppercase;
-    font-family: bryant;
+    font-family: var(--font-display);
     font-size: 1.083rem
 }
 
@@ -599,7 +602,7 @@ code,pre,tt {
     margin-top: 2rem;
     margin-bottom: 0;
     text-transform: uppercase;
-    font-family: bryant;
+    font-family: var(--font-display);
     font-size: 0.917rem
 }
 
@@ -607,7 +610,7 @@ code,pre,tt {
     margin-top: 2rem;
     margin-bottom: 0;
     text-transform: uppercase;
-    font-family: bryant;
+    font-family: var(--font-display);
     font-size: 0.833rem
 }
 
@@ -615,7 +618,7 @@ code,pre,tt {
     margin-top: 2rem;
     margin-bottom: 0;
     text-transform: uppercase;
-    font-family: bryant;
+    font-family: var(--font-display);
     font-size: 0.75rem
 }
 
@@ -889,7 +892,7 @@ code,pre,tt {
 .post .post-tags .tags-title {
     position: relative;
     text-transform: uppercase;
-    font-family: bryant;
+    font-family: var(--font-display);
     margin-right: .5rem;
     padding-right: 40px
 }
@@ -969,10 +972,9 @@ code,pre,tt {
 .post-heading>.date {
     margin-left: 2px;
     text-transform: uppercase;
-    font-family: moniker;
     font-size: 0.625rem;
     color: var(--color-primary-light);
-    font-family: bryant;
+    font-family: var(--font-display);
     font-weight: 700
 }
 
@@ -1141,7 +1143,7 @@ code,pre,tt {
     text-decoration: none;
     text-shadow: 0 1px var(--color-background);
     color: var(--color-primary);
-    font-family: moniker
+    font-family: var(--font-sans)
 }
 
 /* ==========================================================================

--- a/_sass/_contact.scss
+++ b/_sass/_contact.scss
@@ -6,20 +6,20 @@
 .contact-email>.e-mail, .contact-email>.address {
     padding-left: 24px;
     color: var(--color-link);
-    font-family: iosevka term;
+    font-family: var(--font-mono);
     font-size: 1.5rem
 }
 
 .pgp .fingerprint>.line {
     text-align: center;
     color: var(--color-link);
-    font-family: iosevka term;
+    font-family: var(--font-mono);
     font-size: 1.167rem
 }
 
 .pgp-key {
     color: var(--color-code);
-    font-family: iosevka term;
+    font-family: var(--font-mono);
     line-height: 1.4;
     font-size: 0.75rem
 }

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -211,7 +211,7 @@
 }
 
 .email-address {
-    font-family: iosevka term;
+    font-family: var(--font-mono);
     line-height: 1.3;
     font-size: 0.875rem;
     font-weight: 400

--- a/assets/js/animations.js
+++ b/assets/js/animations.js
@@ -1,6 +1,16 @@
 function loadImage(id, targetId) {
     var el = document.getElementById(id);
+    if (!el) {
+        console.warn('loadImage: element not found for id "' + id + '"');
+        return;
+    }
+
     var targetEl = targetId ? document.getElementById(targetId) : el;
+    if (targetId && !targetEl) {
+        console.warn('loadImage: target element not found for id "' + targetId + '"');
+        return;
+    }
+
     var imageToLoad;
     if (el.dataset.image) {
         imageToLoad = el.dataset.image;

--- a/index.html
+++ b/index.html
@@ -40,9 +40,9 @@ layout: default
             <a id="GeekMag" href="https://web.archive.org/web/20180828031811/https://www.geekmag.es/" class="project">
                 <div class="project-borders">
 					<picture>
-                        <source srcset="/assets/images/GeekMag.webp" type="image/webp">
-                        <source srcset="/assets/images/GeekMag.png" type="image/png">
-                        <img id="GeekMagScreenshot" src="/assets/images/GeekMag.png" alt="Screenshot of GeekMag" class="screenshot" width="744" height="445">
+                        <source srcset="{{ '/assets/images/GeekMag.webp' | relative_url }}" type="image/webp">
+                        <source srcset="{{ '/assets/images/GeekMag.png' | relative_url }}" type="image/png">
+                        <img id="GeekMagScreenshot" src="{{ '/assets/images/GeekMag.png' | relative_url }}" alt="Screenshot of GeekMag" class="screenshot" width="744" height="445" loading="lazy" decoding="async" fetchpriority="low">
                     </picture>
                     <b>GeekMag</b> was an online publication focused on technology, science, movies and videogames.
                 </div>


### PR DESCRIPTION
**Summary**  
- Prefer `page.image | default: site.logo | absolute_url` for Open Graph/Twitter cards so shares pick the correct preview asset.  
- Route all internal links and assets through `relative_url`, keeping the theme deployable under subpaths.  
- Guard `loadImage` against missing DOM IDs and add lazy-loading hints to the homepage project screenshot for stability and performance.  
- Define shared font-stack variables (`--font-sans`, `--font-display`, `--font-mono`) and apply them across headings, metadata, and code blocks for graceful fallbacks.
