### PR TITLE
Spelling review

### DIFF
--- a/_posts/2019-11-07-block-cipher-operation-modes.md
+++ b/_posts/2019-11-07-block-cipher-operation-modes.md
@@ -34,7 +34,7 @@ For this reason the modes of operations appears.
 
 ### ECB mode of operation
 
-[Electronic Code Book](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Electronic_Codebook_(ECB)) (ECB) is the simplest one. In fact, we have already explained it. Each message's block is encrypted separately and that provokes the problem above mentioned.
+[Electronic Code Book](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Electronic_Codebook_(ECB)) (ECB) is the simplest one. In fact, we have already explained it. Each message’s block is encrypted separately and that provokes the problem above mentioned.
 
 If \\( E(\cdot) \\) is the cipher function for encrypt, \\( D(\cdot) \\) is the cipher function for decrypt, \\( P_i \\) and \\( C_i \\) are the i-th block of the plaintext and ciphertext respectively, and \\( k \\) is the key.
 

--- a/_posts/2021-10-17-introduction-support-vector-machines-svm.md
+++ b/_posts/2021-10-17-introduction-support-vector-machines-svm.md
@@ -18,7 +18,7 @@ Support vector machines are found within machine learning in a field called supe
 
 They are maximum margin classifiers using the **kernel trick** to project the training data samples into a higher-dimensional space, making them linearly separable (or nearly separable).
 
-Let's borrow a [great explanation of SVMs](https://www.reddit.com/r/MachineLearning/comments/15zrpp/comment/c7rkwce/?utm_source=share&utm_medium=web2x&context=3) for dummies:
+Let’s borrow a [great explanation of SVMs](https://www.reddit.com/r/MachineLearning/comments/15zrpp/comment/c7rkwce/?utm_source=share&utm_medium=web2x&context=3) for dummies:
 
 We have balls of two colors (red and blue) on a table that we want to separate or classify.
 

--- a/_posts/2022-06-07-an-introduction-to-queuing-theory.md
+++ b/_posts/2022-06-07-an-introduction-to-queuing-theory.md
@@ -33,17 +33,17 @@ The following distinct components can be found in any queueing system:
 
 ![Structure of a queueing system]({{ '/assets/images/blog/an-introduction-to-queueing-theory/queueing-system-diagram.webp' | absolute_url }}){: .align-center}
 
-## Kendall's notation
+## Kendall’s notation
 
 Kendall defined a notation to describe queueing models based on six characteristics (A/S/c/K/m/z) where:
 
 - **A** specifies what the **arrival process** is like: whether inter-arrivals are i.i.d and Poissonian **M**, deterministic **D**, or follow some general distribution **GI**.
 - **S** determines the **service time distribution** type. It is used the same notation as for arrivals.
 - **c** is the **number of servers**.
-- **K** is the **system's capacity** or the number of places in the queue. If it is presumed to be infinity, it will be blank.
+- **K** is the **system’s capacity** or the number of places in the queue. If it is presumed to be infinity, it will be blank.
 - **N** is the **population size**. If the population is presumed to be infinity, it will be also blank.
-- **D** determines the **queue's discipline**, or how priority is distributed among arriving customers. Whether it is a FIFO, LIFO, SIRO... If it is a FIFO queue it is not necessary to indicate it.
+- **D** determines the **queue’s discipline**, or how priority is distributed among arriving customers. Whether it is a FIFO, LIFO, SIRO... If it is a FIFO queue it is not necessary to indicate it.
 
 For example, the notation that would be used for a system with a Poissonian arrival and service rate, a single server, infinite capacity, and population, and a FIFO queue would be M/M/1.
 
-With this, we could conclude this small approach to queueing theory. These systems are present in any area of our life. Without a doubt, getting to know them is exciting, don't you think so?
+With this, we could conclude this small approach to queueing theory. These systems are present in any area of our life. Without a doubt, getting to know them is exciting, don’t you think so?

--- a/_posts/2022-12-13-understanding-apache-spark-runtime-architecture.md
+++ b/_posts/2022-12-13-understanding-apache-spark-runtime-architecture.md
@@ -23,7 +23,7 @@ In addition to the driver and executors, the Spark runtime architecture also inc
 
 ### Driver
 
-The driver is the central component of the Apache Spark runtime architecture. It is responsible for running the user's main function and creating the **SparkContext**, which is the main entry point for interacting with Spark. The driver also communicates with the cluster manager to acquire resources on the cluster and to schedule the execution of tasks on the worker nodes. It monitors the progress of tasks and provides status updates to the user, and it handles the flow of data between the various components of the application. In short, the driver coordinates the execution of a Spark application and is essential to its functioning.
+The driver is the central component of the Apache Spark runtime architecture. It is responsible for running the user’s main function and creating the **SparkContext**, which is the main entry point for interacting with Spark. The driver also communicates with the cluster manager to acquire resources on the cluster and to schedule the execution of tasks on the worker nodes. It monitors the progress of tasks and provides status updates to the user, and it handles the flow of data between the various components of the application. In short, the driver coordinates the execution of a Spark application and is essential to its functioning.
 
 ### Executors
 

--- a/_posts/2025-11-08-spark-memory-fundamentals-executor-allocation.md
+++ b/_posts/2025-11-08-spark-memory-fundamentals-executor-allocation.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Spark Memory Fundamentals: How Executors Really Allocate Memory"
 description: "Ever wondered why your Spark jobs run out of memory? Learn how Spark divides executor memory, manages dynamic borrowing between storage and execution, and why some tasks spill to disk while others fly through."
-last_modified_at: 2025-11-09 12:32 +0100
+last_modified_at: 2025-11-10 14:22 +0100
 image: "/assets/images/blog/spark-memory-fundamentals-executor-allocation.webp"
 categories: "Big Data"
 tags: [Big Data, Spark, Apache, Memory Management, Performance]


### PR DESCRIPTION
Improve typography by converting straight apostrophes (') used as contractions/possessives in prose to typographic apostrophes (’), across Markdown posts. Changes avoid code fences, inline code, and markdown link/title syntax